### PR TITLE
Add two optional values, scaleX and scaleY to the returned relativ array

### DIFF
--- a/element-bounds.js
+++ b/element-bounds.js
@@ -4,20 +4,20 @@ module.exports = function(el) {
   var targetY = 0;
   var targetWidth = 0;
   var targetHeight = 0;
+  var scaleX = 1;
+  var scaleY = 1;
 
   // get the width and height from the client bounding rect
   targetWidth = rect ? rect.width : 0;
   targetHeight = rect ? rect.height : 0;
 
-  // get the offset from offsetLeft and offsetTop
-  targetX = 0;
-  targetY = 0;
-  while (el) {
-    targetX += el.offsetLeft;
-    targetY += el.offsetTop;
+  // Use the bounding rects left & top
+  targetX = rect ? rect.left : 0;
+  targetY = rect ? rect.top : 0;
 
-    el = el.offsetParent;
-  }
+  // Calculate the scale factors
+  scaleX = el ? targetWidth / el.offsetWidth : 0;
+  scaleY = el ? targetHeight / el.offsetHeight : 0;
 
-  return [targetX, targetY, targetWidth, targetHeight];
+  return [targetX, targetY, targetWidth, targetHeight, scaleX, scaleY];
 };


### PR DESCRIPTION
Returns the scale factors from element-bounds as array elements 5 and 6.

@DamonOehlman I think I'll leave knowledge of the scaling out of the actual relativ function for the moment, as I'm not sure it belongs there.
