### PR TITLE
Constrain the relative values within the bounds of the min/max values

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,18 @@ module.exports = function(bounds, max) {
   var maxX = minX + width;
   var maxY = minY + height;
 
-  function pack(vec) {
-    var relX = vec[0] - minX;
-    var relY = vec[1] - minY;
+  function relative(val, min, size) {
+    var rel = (val - min) / size;
+    // Only allow negative and values > max if unconstrained
+    if (rel > 1) rel = 1;
+    if (rel < 0) rel = 0;
+    return rel * max;
+  }
 
-    return [((relX / width) * max) | 0, ((relY / height) * max) | 0];
+  function pack(vec) {
+    var relX = relative(vec[0], minX, width);
+    var relY = relative(vec[1], minY, height);
+    return [relX | 0, relY | 0];
   }
 
   function unpack(vec) {

--- a/test/non-zero-based.js
+++ b/test/non-zero-based.js
@@ -24,6 +24,16 @@ test('transform [500,400]', function(t) {
   t.deepEqual(transform([500, 400]), [MAXVAL >> 1, MAXVAL >> 1]);
 });
 
+test('transform [1000, 800] (larger than width/height)', function(t) {
+  t.plan(1);
+  t.deepEqual(transform([1000, 800]), [MAXVAL, MAXVAL]);
+});
+
+test('transform [0, 50] (smaller than min width/height)', function(t) {
+  t.plan(1);
+  t.deepEqual(transform([0, 50]), [0, 0]);
+});
+
 test('unpack [0, 0]', function(t) {
   t.plan(1);
   t.deepEqual(transform.unpack([0, 0]), [0, 0]);

--- a/test/zero-based.js
+++ b/test/zero-based.js
@@ -24,6 +24,16 @@ test('transform [400,300]', function(t) {
   t.deepEqual(transform([400, 300]), [MAXVAL >> 1, MAXVAL >> 1]);
 });
 
+test('transform [1000, 800] (larger than width/height)', function(t) {
+  t.plan(1);
+  t.deepEqual(transform([1000, 800]), [MAXVAL, MAXVAL]);
+});
+
+test('transform [-100, -100] (smaller than min width/height)', function(t) {
+  t.plan(1);
+  t.deepEqual(transform([-100, -100]), [0, 0]);
+});
+
 test('unpack [0, 0]', function(t) {
   t.plan(1);
   t.deepEqual(transform.unpack([0, 0]), [0, 0]);


### PR DESCRIPTION
Prevents negative values or values > max from being generated.

I considered putting in an option to allow for values outside of the min/max values, but the precision of the outputted relative values results in a loss of precision that means pack/unpack no longer guarantees equality of the input values to pack, to the output values from unpack.
